### PR TITLE
セット追加フォームの初期値設定とworkoutsコントローラーdestroyアクションのredirect先を調整

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -41,7 +41,7 @@ class WorkoutsController < ApplicationController
 
   def destroy
     @workout.destroy
-    redirect_to workouts_path, notice: "ワークアウトを削除しました", status: :see_other
+    redirect_to workouts_path(date: @workout.performed_on), notice: "ワークアウトを削除しました", status: :see_other
   end
 
   def new_set

--- a/app/views/workouts/new_set.html.erb
+++ b/app/views/workouts/new_set.html.erb
@@ -17,12 +17,12 @@
   <%= form_with model: @set, url: create_set_workout_path(@workout), local: true do |f| %>
     <div class="mb-3">
       <%= f.label :weight, "重量(kg)", class: "form-label" %>
-      <%= f.number_field :weight, step: 0.5, class: "form-control" %>
+      <%= f.number_field :weight, step: 0.5, value: nil, class: "form-control" %>
     </div>
 
     <div class="mb-3">
       <%= f.label :reps, "回数(回)", class: "form-label" %>
-      <%= f.number_field :reps, class: "form-control" %>
+      <%= f.number_field :reps, value: nil, class: "form-control" %>
     </div>
 
     <div class="d-flex gap-2">


### PR DESCRIPTION
## 概要
- セット追加フォーム（重量、回数）の初期値を0からnilに変更
- ワークアウトを削除したときに、日付を維持してindexに遷移するよう調整
### 詳細
- new_set.html.erbの重量、回数フォーム部分にdefault値（０）がセットされてしまっていて入力のたび消去するのが面倒に感じたので、value: nilを追加し空欄に変更しました
- ワークアウトを削除したとき、強制的に今日の日付に遷移してしまっていたので、日付を維持できるよう、workouts_path(date: @workout.performed_on)を追加しました