### PR TITLE
ワークアウト一覧の表示順を作成順に変更

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -9,7 +9,7 @@ class WorkoutsController < ApplicationController
                   current_user.workouts
                     .includes(exercise: :category, workout_sets: [])
                     .where(performed_on: @selected_date)
-                    .order("categories.name, exercises.name")
+                    .order(created_at: :asc)
                 else
                   []
                 end


### PR DESCRIPTION
## 概要
ワークアウト一覧の表示順を種目名順から作成日時順に変更しました
### 詳細
workoutsコントローラー、indexアクションの@workoutsを.order("categories.name, exercises.name")から.order(created_at: :asc)に変更