### PR TITLE
種目管理ページの種目追加ボタンUIを調整

### DIFF
--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -1,14 +1,12 @@
 <div class="container mt-2">
-  <div class="d-flex flex-column flex-md-row justify-content-between align-items-start mb-3">
-    <h2 class="mb-3 mb-md-0">種目管理</h2>
+  <h2 class="mb-3">種目管理</h2>
 
-    <div class="card border-success p-2" style="min-width: 200px; max-width: 300px;">
-      <div class="card-header bg-success text-white py-1">
-        新しい種目を追加
-      </div>
-      <div class="card-body p-2">
-        <%= render partial: "add_form", locals: { exercise: Exercise.new(category: @selected_category) } %>
-      </div>
+  <div class="card shadow-sm mb-3 w-100 border-0">
+    <div class="card-header bg-success text-white py-1">
+      新しい種目を追加
+    </div>
+    <div class="card-body p-2">
+      <%= render partial: "add_form", locals: { exercise: Exercise.new(category: @selected_category) } %>
     </div>
   </div>
 
@@ -24,7 +22,7 @@
 
   <div class="list-group">
     <% @exercises.each do |exercise| %>
-      <%= render partial: "exercise", locals: {exercise: exercise} %>
+      <%= render partial: "exercise", locals: { exercise: exercise } %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
種目管理ページの種目追加ボタンUIを調整
- タイトルの下に配置
- 横幅いっぱいになるよう調整
- カードの外枠をなくし、影で境界がわかるように変更