### PR TITLE
種目編集をキャンセルしたときのエラー解消

### DIFF
--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -13,9 +13,9 @@
 
       <%= f.submit "更新", class: "btn btn-sm btn-success" %>
       <%= link_to "キャンセル",
-            exercises_path,
-            data: { turbo_frame: dom_id(@exercise) },
-            class: "btn btn-secondary btn-sm" %>
+            exercises_path(category_id: @exercise.category_id),
+            class: "btn btn-secondary btn-sm",
+            data: { turbo: false } %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
種目管理画面で胸カテゴリー以外の種目を編集→キャンセルしたときに、TurboFrameMissingErrorがおきたので、解消するためにキャンセルリンクのturboをオフにしました。