### PR TITLE
uidのバリデーションが通常ユーザーに適用されないよう変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
 
   validates :username, presence: true,
                        length: { maximum: 20 }
-  validates :uid, uniqueness: { scope: :provider}
+  validates :uid, uniqueness: { scope: :provider}, if: :sns_user?
 
   after_create :copy_default_exercises
 


### PR DESCRIPTION
uidのバリデーションが通常ユーザーにも適用されてしまい、プロフィール編集の際エラーが発生してしまったので、SNSログインユーザーのみに適用されるよう編集しました。